### PR TITLE
Typo fixes

### DIFF
--- a/app/views/lpa-submission/statutory-extra-details.html
+++ b/app/views/lpa-submission/statutory-extra-details.html
@@ -17,7 +17,7 @@
         id: "statutory-extra-details",
         name: "statutory-extra-details",
         label: {
-          text: "Tell us what sections of the statutory development plan are relevant (optional)",
+          text: "Tell us which sections of the Statutory Development Plan are relevant (optional)",
           classes: "govuk-label--l",
           isPageHeading: true
         }

--- a/app/views/lpa-submission/supplementary-existing-list.html
+++ b/app/views/lpa-submission/supplementary-existing-list.html
@@ -57,11 +57,11 @@
         <fieldset class="govuk-fieldset" aria-describedby="supp-docs-used-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              What Supplementary Planning Documents were used?
+              Which Supplementary Planning Documents were used?
             </h1>
           </legend>
           <div id="supp-docs-used-hint" class="govuk-hint">
-            Select all that apply.
+            Select all that apply or add relevant documents not already listed.
           </div>
           <div class="govuk-checkboxes">
             <h3 class="govuk-heading-s">Adopted documents</h3>


### PR DESCRIPTION
Corrected a couple of typos in the H1 of supplementary planning docs - add existing docs screen, and also the extra information screen added to the statutory planning doc section.