### PR TITLE
Task list and CYA updates

### DIFF
--- a/app/routes/lpa-questionnaire/v8.js
+++ b/app/routes/lpa-questionnaire/v8.js
@@ -1,6 +1,7 @@
 module.exports = function (router) {
 
   var base = "/lpa-questionnaire/v8/";
+  var v = "v8";
 
   // Security - not required for v8
   /*
@@ -17,88 +18,130 @@ module.exports = function (router) {
   // About the appeal
 
     router.post(base+'about-appeal/review-accuracy', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappeal-accurate');
     })
 
     router.post(base+'about-appeal/conditions', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappeal-conditions');
     })
 
     router.post(base+'about-appeal/other-appeals', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappeal-otherappeals');
     })
 
     router.post(base+'about-appeal/interested-parties', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappeal-interestedparties');
     })
 
 
   // About the appeal site
   
     router.post(base+'about-appeal-site/public-land', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-publicland');
     })
   
     router.post(base+'about-appeal-site/enter-site', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-entersite');
     })
   
     router.post(base+'about-appeal-site/neighbours-land', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-neighboursland');
     })
   
     router.post(base+'about-appeal-site/listed-building', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-listedbuilding');
     })
   
     router.post(base+'about-appeal-site/green-belt', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-greenbelt');
     })
   
     router.post(base+'about-appeal-site/conservation-area', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutappealsite-conservationarea');
     })
 
 
   // About the planning application
   
     router.post(base+'about-planning-application/upload-plans', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-uploadplans');
     })
   
     router.post(base+'about-planning-application/officers-report', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-officersreport');
     })
   
     router.post(base+'about-planning-application/site-notices', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-sitenotices');
     })
   
     router.post(base+'about-planning-application/interested-parties', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-interestedparties');
     })
   
     router.post(base+'about-planning-application/representations', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-representations');
     })
   
     router.post(base+'about-planning-application/planning-history', function (req, res) {
-      res.redirect(base+'task-list');
+      res.redirect(base+'task-list#aboutplanningapplication-planninghistory');
     })
 
 
     // Policies related to the planning application
     
       router.post(base+'related-policies/statutory', function (req, res) {
-        res.redirect(base+'task-list');
+        res.redirect(base+'task-list#relatedpolicies-statutory');
       })
     
       router.post(base+'related-policies/relevant', function (req, res) {
-        res.redirect(base+'task-list');
+        res.redirect(base+'task-list#relatedpolicies-relevant');
       })
     
       router.post(base+'related-policies/development-plan', function (req, res) {
-        res.redirect(base+'task-list');
+        res.redirect(base+'task-list#relatedpolicies-developmentplan');
       })
+
+    
+      // Jump to completed task list
+
+        router.get(base+'jump/tasks-complete', function (req, res) {
+
+          // About the appeal answers
+          req.session.data['lpaq-'+v+'-aboutappeal-accurate'] = "No"
+          req.session.data['lpaq-'+v+'-aboutappeal-accurate-whynot'] = "A reason as to why the information doesn't accurately reflect the original planning application."
+          req.session.data['lpaq-'+v+'-aboutappeal-conditions'] = "Yes"
+          req.session.data['lpaq-'+v+'-aboutappeal-conditions-listconditions'] = "There are a few extra conditions that will be listed here"
+          req.session.data['lpaq-'+v+'-aboutappeal-otherappeals'] = "Yes"
+          req.session.data['lpaq-'+v+'-aboutappeal-otherappeals-listappeals'] = "654654, 987987, 321321"
+          req.session.data['lpaq-'+v+'-aboutappeal-interestedparties'] = "No"
+
+          //Abbout the appeal site answers
+          req.session.data['lpaq-'+v+'-aboutappealsite-publicland'] = "No"
+          req.session.data['lpaq-'+v+'-aboutappealsite-entersite'] = "Yes"
+          req.session.data['lpaq-'+v+'-aboutappealsite-entersite-telluswhy'] = "There's a 60ft wall that you can't peek over"
+          req.session.data['lpaq-'+v+'-aboutappealsite-neighboursland'] = "Yes"
+          req.session.data['lpaq-'+v+'-aboutappealsite-neighboursland-telluswhy'] = "22 Argyll Street. Maidstone. This is a reason why you think a visit is required."
+          req.session.data['lpaq-'+v+'-aboutappealsite-listedbuilding'] = "Yes"
+          req.session.data['lpaq-'+v+'-aboutappealsite-listedbuilding-telluswhy'] = "This is the relevant listing description from the List of Buildings of Special Architectural or Historic Interest"
+          req.session.data['lpaq-'+v+'-aboutappealsite-greenbelt'] = "No"
+          req.session.data['lpaq-'+v+'-aboutappealsite-conservationarea'] = "No"
+          
+          // About the planning application answers
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-uploadplans'] = "uploaded"
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-officersreport'] = "uploaded"
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-sitenotices'] = "No"
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-interestedparties'] = "uploaded"
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-representations'] = "uploaded"
+          req.session.data['lpaq-'+v+'-aboutplanningapplication-planninghistory'] = "uploaded"
+          
+          // Policies related to the planning application answers (blank as optional)
+          req.session.data['lpaq-'+v+'-relatedpolicies-statutory'] = ""
+          req.session.data['lpaq-'+v+'-relatedpolicies-relevant'] = ""
+          req.session.data['lpaq-'+v+'-relatedpolicies-developmentplan'] = ""
+
+          // Show Check your answers
+          res.redirect(base+'check-your-answers');
+        })
 
 }

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -449,6 +449,7 @@
                     <li>
                       <a href="/lpa-questionnaire/v8/email/started" title="">Start journey from 'Householder appeal started' email</a>
                     </li>
+                    <li><a href="/lpa-questionnaire/v8/jump/tasks-complete" class="govuk-link">Jump to Check You Answers</a></li>
                   </ul>
 
                   <!--details class="govuk-details" data-module="govuk-details">

--- a/app/views/layouts/lpa-questionnaire/v8.html
+++ b/app/views/layouts/lpa-questionnaire/v8.html
@@ -1,4 +1,4 @@
-{% set serviceName = "Reply to a householder planning appeal" %}
+{% set serviceName = "Appeal a householder planning decision" %}
 {%- set version = 'v8' -%}
   
 {#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}

--- a/app/views/lpa-questionnaire/v8/about-appeal-site/conservation-area.html
+++ b/app/views/lpa-questionnaire/v8/about-appeal-site/conservation-area.html
@@ -31,6 +31,37 @@
     
     <form action="" method="post">
 
+      {% set uploadHtml %}
+        {{ govukFileUpload({
+          id: "casefile",
+          name: "casefile",
+          classes: 'moj-multi-file-upload__input',
+          label: {
+            text: "Upload files",
+            classes: 'govuk-label--m'
+          },
+          attributes: { multiple: '' },
+          errorMessage: errorMessage
+        }) }}
+
+        {{govukButton({
+          text: 'Upload file',
+          classes: 'govuk-button--secondary moj-multi-file-upload__button'
+        })}}
+      {% endset %}
+
+      {% set conditionalHtml %}
+
+        {{ mojMultiFileUpload({
+          uploadedFiles: {
+            heading: { text: 'Files added' },
+            items: data.uploadedFiles | filesByFieldName("conservationareamap")
+          },
+          uploadHtml: uploadHtml
+        }) }}
+
+      {% endset %}
+
       {{ govukRadios({
         idPrefix: "lpaq-"+version+"-aboutappealsite-conservationarea",
         name: "lpaq-"+version+"-aboutappealsite-conservationarea",
@@ -38,7 +69,10 @@
           {
             value: "Yes",
             text: "Yes",
-            checked: checked("lpaq-"+version+"-aboutappealsite-conservationarea", "Yes")
+            checked: checked("lpaq-"+version+"-aboutappealsite-conservationarea", "Yes"),
+            conditional: {
+              html: conditionalHtml
+            }
           },
           {
             value: "No",
@@ -60,4 +94,18 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block pageScripts %}
+  <script>
+    if(typeof MOJFrontend.MultiFileUpload !== 'undefined') {
+
+      new MOJFrontend.MultiFileUpload({
+        container: $('.moj-multi-file-upload'),
+        uploadUrl: '/ajax-case-file',
+        deleteUrl: '/ajax-case-file-delete',
+        fieldName: 'conservationareamap'
+        });
+    }
+  </script>
 {% endblock %}

--- a/app/views/lpa-questionnaire/v8/check-your-answers.html
+++ b/app/views/lpa-questionnaire/v8/check-your-answers.html
@@ -45,7 +45,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal/review-accuracy">
               Change<span class="govuk-visually-hidden"> does the information from the appellant accurately reflect the original planning application?</span>
             </a>
           </dd>
@@ -61,7 +61,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal/conditions">
               Change<span class="govuk-visually-hidden"> do you have any extra conditions?</span>
             </a>
           </dd>
@@ -77,7 +77,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal/other-appeals">
               Change<span class="govuk-visually-hidden"> are there any other appeals adjacent or close to the site still being considered?</span>
             </a>
           </dd>
@@ -90,7 +90,7 @@
             {{ data["lpaq-"+version+"-aboutappeal-interestedparties"] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal/interested-parties">
               Change<span class="govuk-visually-hidden"> have you notified interested parties about the appeal?</span>
             </a>
           </dd>
@@ -108,7 +108,7 @@
             {{ data["lpaq-"+version+"-aboutappealsite-publicland"] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/public-land">
               Change<span class="govuk-visually-hidden"> can the Inspector see the relevant parts of the appeal site from public land?</span>
             </a>
           </dd>
@@ -124,7 +124,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/enter-site">
               Change<span class="govuk-visually-hidden"> will the Inspector need to enter the appeal site?</span>
             </a>
           </dd>
@@ -140,7 +140,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/neighbours-land">
               Change<span class="govuk-visually-hidden"> would the Inspector need access to a neighbour's land?</span>
             </a>
           </dd>
@@ -156,7 +156,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/listed-building">
               Change<span class="govuk-visually-hidden"> would the development affect the setting of a listed building?</span>
             </a>
           </dd>
@@ -169,7 +169,7 @@
             {{ data["lpaq-"+version+"-aboutappealsite-greenbelt"] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/green-belt">
               Change<span class="govuk-visually-hidden"> is the appeal site in a green belt?</span>
             </a>
           </dd>
@@ -182,7 +182,7 @@
             {{ data["lpaq-"+version+"-aboutappealsite-conservationarea"] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-appeal-site/conservation-area">
               Change<span class="govuk-visually-hidden"> is the appeal site in or near a conservation area?</span>
             </a>
           </dd>
@@ -208,7 +208,7 @@
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/upload-plans">
               Change<span class="govuk-visually-hidden"> upload the plans used to reach the decision</span>
             </a>
           </dd>
@@ -226,7 +226,7 @@
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/officers-report">
               Change<span class="govuk-visually-hidden"> upload the Planning Officer's report</span>
             </a>
           </dd>
@@ -239,7 +239,7 @@
             {{ data["lpaq-"+version+"-aboutplanningapplication-sitenotices"] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/site-notices">
               Change<span class="govuk-visually-hidden"> did you publicise the original planning application?</span>
             </a>
           </dd>
@@ -257,7 +257,7 @@
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/interested-parties">
               Change<span class="govuk-visually-hidden"> telling interested parties about the application</span>
             </a>
           </dd>
@@ -275,7 +275,7 @@
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/representations">
               Change<span class="govuk-visually-hidden"> representations from interested parties</span>
             </a>
           </dd>
@@ -302,7 +302,7 @@
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="about-planning-application/planning-history">
               Change<span class="govuk-visually-hidden"> planning history</span>
             </a>
           </dd>
@@ -324,7 +324,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="related-policies/statutory">
               Change<span class="govuk-visually-hidden"> statutory development plan policy</span>
             </a>
           </dd>
@@ -341,7 +341,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="related-policies/relevant">
               Change<span class="govuk-visually-hidden"> statutory development plan policy</span>
             </a>
           </dd>
@@ -358,7 +358,7 @@
             {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="related-policies/development-plan">
               Change<span class="govuk-visually-hidden"> statutory development plan policy</span>
             </a>
           </dd>

--- a/app/views/lpa-questionnaire/v8/task-list.html
+++ b/app/views/lpa-questionnaire/v8/task-list.html
@@ -49,7 +49,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal/review-accuracy" class="govuk-link">
+                <a href="about-appeal/review-accuracy" class="govuk-link" id="aboutappeal-accurate">
                   Review accuracy of the appellant's submission
                 </a>
               </span>
@@ -62,7 +62,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal/conditions" class="govuk-link">
+                <a href="about-appeal/conditions" class="govuk-link" id="aboutappeal-conditions">
                   Do you have any extra conditions?
                 </a>
               </span>
@@ -75,7 +75,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal/other-appeals" class="govuk-link">
+                <a href="about-appeal/other-appeals" class="govuk-link" id="aboutappeal-otherappeals">
                   Tell us about any appeals in the immediate area
                 </a>
               </span>
@@ -88,7 +88,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal/interested-parties" class="govuk-link">
+                <a href="about-appeal/interested-parties" class="govuk-link" id="aboutappeal-interestedparties">
                   Notifying interested parties of the appeal
                 </a>
               </span>
@@ -109,7 +109,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/public-land" class="govuk-link">
+                <a href="about-appeal-site/public-land" class="govuk-link" id="aboutappealsite-publicland">
                   Can the Inspector see the relevant parts of the appeal site from public land?
                 </a>
               </span>
@@ -122,7 +122,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/enter-site" class="govuk-link">
+                <a href="about-appeal-site/enter-site" class="govuk-link" id="aboutappealsite-entersite">
                   Will the inspector need to enter the appeal site?
                 </a>
               </span>
@@ -135,7 +135,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/neighbours-land" class="govuk-link">
+                <a href="about-appeal-site/neighbours-land" class="govuk-link" id="aboutappealsite-neighboursland">
                   Would the Inspector need access to a neighbour's land?
                 </a>
               </span>
@@ -148,7 +148,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/listed-building" class="govuk-link">
+                <a href="about-appeal-site/listed-building" class="govuk-link" id="aboutappealsite-listedbuilding">
                   Would this affect the setting of a listed building?
                 </a>
               </span>
@@ -161,7 +161,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/green-belt" class="govuk-link">
+                <a href="about-appeal-site/green-belt" class="govuk-link" id="aboutappealsite-greenbelt">
                   Is the appeal site in a green belt?
                 </a>
               </span>
@@ -174,7 +174,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-appeal-site/conservation-area" class="govuk-link">
+                <a href="about-appeal-site/conservation-area" class="govuk-link" id="aboutappealsite-conservationarea">
                   Is the appeal site in or near a conservation area?
                 </a>
               </span>
@@ -196,7 +196,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/upload-plans" class="govuk-link">
+                <a href="about-planning-application/upload-plans" class="govuk-link" id="aboutplanningapplication-uploadplans">
                   Upload the plans used to reach the decision
                 </a>
               </span>
@@ -209,7 +209,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/officers-report" class="govuk-link">
+                <a href="about-planning-application/officers-report" class="govuk-link" id="aboutplanningapplication-officersreport">
                   Upload the Planning Officer's report
                 </a>
               </span>
@@ -222,7 +222,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/site-notices" class="govuk-link">
+                <a href="about-planning-application/site-notices" class="govuk-link" id="aboutplanningapplication-sitenotices">
                   Site notices
                 </a>
               </span>
@@ -235,7 +235,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/interested-parties" class="govuk-link">
+                <a href="about-planning-application/interested-parties" class="govuk-link" id="aboutplanningapplication-interestedparties">
                   Telling interested parties about the application
                 </a>
               </span>
@@ -248,7 +248,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/representations" class="govuk-link">
+                <a href="about-planning-application/representations" class="govuk-link" id="aboutplanningapplication-representations">
                   Representations from interested parties
                 </a>
               </span>
@@ -261,7 +261,7 @@
 
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="about-planning-application/planning-history" class="govuk-link">
+                <a href="about-planning-application/planning-history" class="govuk-link" id="aboutplanningapplication-planninghistory">
                   Planning history
                 </a>
               </span>
@@ -332,7 +332,7 @@
             -->
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="related-policies/statutory" class="govuk-link">
+                <a href="related-policies/statutory" class="govuk-link" id="relatedpolicies-statutory">
                   Statutory development plan policy
                 </a>
               </span>
@@ -345,7 +345,7 @@
             
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="related-policies/relevant" class="govuk-link">
+                <a href="related-policies/relevant" class="govuk-link" id="relatedpolicies-relevant">
                   Other relevant policies
                 </a>
               </span>
@@ -358,7 +358,7 @@
             
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="related-policies/development-plan" class="govuk-link">
+                <a href="related-policies/development-plan" class="govuk-link" id="relatedpolicies-developmentplan">
                   Development Plan Document or Neighbourhood Plan
                 </a>
               </span>
@@ -399,7 +399,7 @@
                 %}
 
                   <span class="app-task-list__task-name">
-                    <a href="/lpa-questionnaire/{{version}}/check-your-answers" class="govuk-link">
+                    <a href="/lpa-questionnaire/{{version}}/check-your-answers" class="govuk-link" id="">
                       Check your answers
                     </a>
                   </span>


### PR DESCRIPTION
- Task list links have IDs that allow the user to be focused back to where they were on the task list after answering a question.
- Change links on 'Check your answers' now link to the relevant questions.
- Added a 'jump' link to set up variables and take the user to the "Check your answers" page with answers.